### PR TITLE
Added optional note field to default header

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,11 @@
             "MIT",
             "GPL3"
           ]
+        },
+        "copyrighter.note": {
+          "type": "string",
+          "default": "",
+          "description": "An optional note that can appear at the end of the default copyright notice."
         }
       }
     }

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -33,7 +33,7 @@ export const configuredLanguages = new Set([
   'java',
   'javascript',
   'rust',
-  'typescript'
+  'typescript',
 ]);
 
 export function getAuthor(): string {
@@ -52,4 +52,8 @@ export function getCopyright(): Copyright {
   } else {
     return new Copyright();
   }
+}
+
+export function getNote(): string {
+  return getConfiguration().get('note') || '';
 }

--- a/src/copyright/copyright.ts
+++ b/src/copyright/copyright.ts
@@ -22,18 +22,25 @@ import * as configuration from '../configuration';
 export class Copyright {
   protected author: string;
   protected year: string;
+  protected note: string;
 
   constructor() {
     this.author = configuration.getAuthor();
     this.year = new Date().getFullYear().toString();
+    this.note = configuration.getNote();
   }
 
   public header(): string {
     let template = `/*
  *   Copyright (c) ${this.year} ${this.author}
- *   All rights reserved.
- */
-\n`;
+ *   All rights reserved.\n`;
+
+    if (this.note) {
+      template += ` *   ${this.note}\n`;
+    }
+
+    template += ` */\n`;
+
     return template;
   }
 }


### PR DESCRIPTION
The note is configurable via the extension settings. It does not show up in the copyright header if it is not set. If it is set, it appears on a new line at the end of the default copyright notice header. For now, this feature is only available on the default header. If there is desire for custom notes on Apache, MIT, etc... headers that can be added in the future.

Fixes #1 