### PR TITLE
Adding Support for only adding copyright for new files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "copyrighter",
-	"version": "0.0.2",
+	"version": "0.0.3",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -73,6 +73,11 @@
           "type": "string",
           "default": "",
           "description": "An optional note that can appear at the end of the default copyright notice."
+        },
+        "copyrighter.newFilesOnly": {
+          "type": "boolean",
+          "default": false,
+          "description": "Inject Copyright notice in new files only"
         }
       }
     }

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -57,3 +57,7 @@ export function getCopyright(): Copyright {
 export function getNote(): string {
   return getConfiguration().get('note') || '';
 }
+
+export function getNewFilesOnly(): Boolean {
+  return getConfiguration().get('newFilesOnly') || false;
+}

--- a/src/copyright/copyrightService.ts
+++ b/src/copyright/copyrightService.ts
@@ -22,7 +22,7 @@ export function handleCopyrightCheck(editor: vscode.TextEditor | undefined) {
   if (
     editor !== undefined &&
     isSupportedLanguage(editor.document.languageId) &&
-    !hasCopyright(editor.document)
+    !hasCopyright(editor.document) && (configuration.getNewFilesOnly() ? isNewDocument(editor.document) : true)
   ) {
     insertCopyright(editor);
   }


### PR DESCRIPTION
#4 

Added option to only inject Copyright for new files

Default setting is false so should be backwards compatible.