### PR TITLE
Adding support for different comment styles + multi-line notes

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -25,7 +25,8 @@ function getConfiguration(): vscode.WorkspaceConfiguration {
   return vscode.workspace.getConfiguration('copyrighter');
 }
 
-export const configuredLanguages = new Set([
+// comment styles '/* */' or '//'
+export const cstyleLanguages = new Set([
   'c',
   'cpp',
   'csharp',
@@ -41,6 +42,17 @@ export const configuredLanguages = new Set([
   'typescript',
   'typescriptreact',
   'vue'
+]);
+
+// comments use '#'
+export const hashtagLanguages = new Set([
+  'python',
+  'shellscript'
+]);
+
+export const configuredLanguages = new Set([
+  ...cstyleLanguages,
+  ...hashtagLanguages
 ]);
 
 export function getAuthor(): string {

--- a/src/copyright/comment.ts
+++ b/src/copyright/comment.ts
@@ -1,0 +1,21 @@
+/*
+ *   Copyright (c) 2019 Ford Motor Company
+ *   All rights reserved.
+
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+
+ *   http://www.apache.org/licenses/LICENSE-2.0
+
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+export enum CommentStyle {
+  CStyle,
+  Hashtag
+}

--- a/src/copyright/copyright.ts
+++ b/src/copyright/copyright.ts
@@ -18,6 +18,7 @@
 'use script';
 
 import * as configuration from '../configuration';
+import * as comment from './comment';
 
 export class Copyright {
   protected author: string;
@@ -30,16 +31,33 @@ export class Copyright {
     this.note = configuration.getNote();
   }
 
-  public header(): string {
-    let template = `/*
- *   Copyright (c) ${this.year} ${this.author}
- *   All rights reserved.\n`;
+  public header(style: comment.CommentStyle): string {
+    let beginningPrefix, midPrefix, endPrefix;
 
-    if (this.note) {
-      template += ` *   ${this.note}\n`;
+    switch (style) {
+      case comment.CommentStyle.CStyle:
+      default:
+        beginningPrefix = '/*';
+        midPrefix = ' *'
+        endPrefix = ' */'
+        break;
+
+      case comment.CommentStyle.Hashtag:
+        beginningPrefix = '#';
+        midPrefix = '#'
+        endPrefix = '#'
+        break;
     }
 
-    template += ` */\n`;
+    let template = `${beginningPrefix}
+${midPrefix}   Copyright (c) ${this.year} ${this.author}
+${midPrefix}   All rights reserved.\n`;
+
+    if (this.note) {
+      template += `${midPrefix}   ${this.note}\n`;
+    }
+
+    template += `${endPrefix}\n`;
 
     return template;
   }

--- a/src/copyright/copyright.ts
+++ b/src/copyright/copyright.ts
@@ -32,7 +32,9 @@ export class Copyright {
   }
 
   public header(style: comment.CommentStyle): string {
-    let beginningPrefix, midPrefix, endPrefix;
+    let beginningPrefix: String;
+    let midPrefix: String;
+    let endPrefix: String;
 
     switch (style) {
       case comment.CommentStyle.CStyle:
@@ -54,7 +56,9 @@ ${midPrefix}   Copyright (c) ${this.year} ${this.author}
 ${midPrefix}   All rights reserved.\n`;
 
     if (this.note) {
-      template += `${midPrefix}   ${this.note}\n`;
+      this.note.split('\n').forEach((line: String) => {
+        template += `${midPrefix}   ${line}\n`;
+      });
     }
 
     template += `${endPrefix}\n`;

--- a/src/copyright/copyrightService.ts
+++ b/src/copyright/copyrightService.ts
@@ -17,6 +17,7 @@
 
 import * as vscode from 'vscode';
 import * as configuration from '../configuration';
+import * as comment from './comment';
 
 export function handleCopyrightCheck(editor: vscode.TextEditor | undefined) {
   if (
@@ -55,7 +56,7 @@ function hasCopyright(document: vscode.TextDocument): Boolean {
 
 function insertCopyright(editor: vscode.TextEditor) {
   const documentStartPosition = new vscode.Position(0, 0);
-  const copyright = configuration.getCopyright().header();
+  const copyright = configuration.getCopyright().header(getCommentStyle(editor.document.languageId));
 
   editor.edit(document => {
     document.insert(documentStartPosition, copyright);
@@ -68,4 +69,16 @@ function isNewDocument(document: vscode.TextDocument): Boolean {
 
 function isSupportedLanguage(languageId: string): Boolean {
   return configuration.configuredLanguages.has(languageId);
+}
+
+function getCommentStyle(languageId: string): comment.CommentStyle {
+  if (configuration.cstyleLanguages.has(languageId)) {
+    return comment.CommentStyle.CStyle;
+  }
+  if (configuration.hashtagLanguages.has(languageId)) {
+    return comment.CommentStyle.Hashtag;
+  }
+
+  // default to C-style (this shouldn't be reached anyway!)
+  return comment.CommentStyle.CStyle;
 }


### PR DESCRIPTION
Languages that don't use `//` or `/* */` for comments, such as Python, may now be supported. Python and Shell scripts have currently been added. This would solve #8.

---

The note can now contain multiple lines (possible by setting `copyrighter.note` in the JSON preferences instead of UI). Previously attempting to do so would result in the comment prefix not being added to each line.