### PR TITLE
added support for systemverilog/verilog

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "copyrighter",
       "version": "0.0.4",
       "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE",

--- a/package.json
+++ b/package.json
@@ -40,8 +40,10 @@
     "onLanguage:scss",
     "onLanguage:swift",
     "onLanguage:sql",
+    "onLanguage:systemverilog",
     "onLanguage:typescript",
     "onLanguage:typescriptreact",
+    "onLanguage:verilog",
     "onLanguage:vue"
   ],
   "main": "./out/extension.js",
@@ -52,6 +54,32 @@
         "title": "Add Copyright"
       }
     ],
+    "languages": [
+      {
+        "id": "systemverilog",
+        "aliases": [
+            "SystemVerilog",
+            "systemverilog",
+            "System Verilog",
+            "Systemverilog"
+        ],
+        "extensions": [
+            ".sv",
+            ".svh"
+        ]
+      },
+      {
+        "id": "verilog",
+        "aliases": [
+            "Verilog",
+            "verilog"
+        ],
+        "extensions": [
+            ".v",
+            ".vh"
+        ]
+    }
+  ],
     "configuration": {
       "title": "Copyrighter",
       "properties": {

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -38,8 +38,10 @@ export const configuredLanguages = new Set([
   'scss',
   'swift',
   'sql',
+  'systemverilog',
   'typescript',
   'typescriptreact',
+  'verilog',
   'vue'
 ]);
 


### PR DESCRIPTION
Verilog/SystemVerilog supports c-style block comments and c-style one-line comments, so the headers generated by this extension will work perfectly for that language. I added support so that this extension identifies Verilog/SystemVerilog.